### PR TITLE
feat: dev flag for frontend reverse proxy to local dev server

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -6,7 +6,7 @@ import (
 	"homework_platform/server/service"
 
 	// "flag"
-	// "log"
+	"log"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -24,7 +24,12 @@ func InitRouter() *gin.Engine {
 	r.Use(cors.New(config))
 
 	// FrontendFS
-	r.Use(middlewares.Frontend(bootstrap.StaticFS))
+    if bootstrap.Dev {
+        log.Println("Dev flag, using frontend reverse proxy to localhost:5173")
+        r.Use(middlewares.FrontendReverseProxy())
+    } else {
+	    r.Use(middlewares.Frontend(bootstrap.StaticFS))
+    }
 
 	/*
 		路由


### PR DESCRIPTION
添加了使用 `--dev` flag 启用前端页面请求反向代理到 localhost:5173 的功能